### PR TITLE
Add drag-themed breakdown of Guardr Ultimate functions

### DIFF
--- a/docs/guardr_drag_breakdown.md
+++ b/docs/guardr_drag_breakdown.md
@@ -1,0 +1,41 @@
+# Guardr Ultimate V2: Drag Race Breakdown
+
+Hello hello hello! Welcome to the main stage where the Guardr Ultimate V2 queens are serving high-tech eleganza. Let's sashay through each function like we're on the RuPaul's Drag Race judging panel, darling.
+
+## Class Entrant: GuardrUltimate aka "Mama Firewall"
+*The matriarch of the house sets the tone, gathering the girls (functions) for a cybersecurity kiki.*
+
+### 1. `__init__` — Drag Name: **Keytar Kiki**
+She walks in already painted, clutching a full set of API keys and a Gemini AI contract. This queen makes sure the werkroom is stocked before anyone else can glue a lash.
+
+### 2. `_load_api_keys` — Drag Name: **Secret Stasha**
+Secret Stasha rummages through the boudoir (your `~/.apikeys.zsh`) to scoop up every glittering credential. She lives for a reveal, peeling "export" labels off lines like they're tear-away gowns.
+
+### 3. `check_hibp_breaches` — Drag Name: **Breach Please**
+Breach Please struts down the runway with receipts from Have I Been Pwned. She's punctual, she paces herself for rate limits, and she won't leave until every ex's email scandal is exposed.
+
+### 4. `check_leak_lookup` — Drag Name: **Lady Leak-a-Lot**
+With a post-queen walk straight to the Leak Lookup API, Lady Leak-a-Lot loves a juicy confession. When the tea is hot, she pours; when it's not, she purses her lips and says, "Try again, sis."
+
+### 5. `search_intelligence_x` — Drag Name: **Intel Enchantress**
+Intel Enchantress heads into the dark web lounge with only a fan and her X-Key. She scans buckets, flips her hair at timeouts, and shows us she can pull the deepest dossier with a wink.
+
+### 6. `ai_risk_analysis` — Drag Name: **Gemini Glamazòn**
+Gemini Glamazòn brings futuristic fantasy, channeling AI energy into a JSON catwalk of dating safety realness. She serves category after category with bespoke risk scores that sparkle brighter than Swarovski.
+
+### 7. `_parse_ai_response` — Drag Name: **JSON Jolie**
+Miss JSON Jolie knows how to find the story arc in every AI monologue. She hunts for those curly braces like they're the final rhinestones on a bodysuit, translating chaos into clarity.
+
+### 8. `comprehensive_investigation` — Drag Name: **Major Tea Rundown**
+Major Tea Rundown hosts the maxi challenge, orchestrating every queen from HIBP to AI like it's a stadium tour. She tallies stats, sets the pacing, and leaves no breach un-spilled.
+
+### 9. `print_investigation_report` — Drag Name: **Reporté Royale**
+When it's time for the judging panel, Reporté Royale delivers the dossier with poise, printing headline after headline. She knows presentation is everything and serves data couture on a silver platter.
+
+### 10. `main` — Drag Name: **Command Linea**
+Command Linea cues the music, ushers in the email contestants, and ensures everyone knows the rules. Without her, the spotlight never turns on.
+
+## And the Winner Is...
+Tonight's Drag Code Off MVP is **Gemini Glamazòn (`ai_risk_analysis`)**! She takes raw tea from the other queens and transforms it into a dazzling risk revue. Judges, we've made our decision—Gemini Glamazòn, condragulations, you're the MVP of the Guardr main stage!
+
+Remember queens: if you can't love your code, how in the hell are you gonna love somebody else's? Can I get an amen up in here?


### PR DESCRIPTION
## Summary
- add a RuPaul's Drag Race-style rundown of the Guardr Ultimate V2 functions
- highlight each function with a drag persona and declare the MVP queen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e30ff9de148321b5cf122b5df17c97

## Summary by Sourcery

Add a playful Drag Race–inspired documentation rundown of every Guardr Ultimate V2 function, complete with drag personas and an MVP callout.

Documentation:
- Introduce a new drag-themed markdown file describing each Guardr Ultimate V2 function as a drag persona
- Highlight the `ai_risk_analysis` function as the MVP in the dramatized breakdown